### PR TITLE
[HOT Fix] Fixed error raising issue #1

### DIFF
--- a/src/main/java/jade/Window.java
+++ b/src/main/java/jade/Window.java
@@ -5,6 +5,8 @@ import org.lwjgl.glfw.GLFWErrorCallback;
 import org.lwjgl.opengl.GL;
 import util.Time;
 
+import java.util.Objects;
+
 import static org.lwjgl.glfw.Callbacks.glfwFreeCallbacks;
 import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.opengl.GL11.*;
@@ -68,7 +70,7 @@ public class Window {
 
         // Terminate GLFW and the free the error callback
         glfwTerminate();
-        glfwSetErrorCallback(null).free();
+        Objects.requireNonNull(glfwSetErrorCallback(null)).free();
     }
 
     public void init() {

--- a/src/main/java/jade/Window.java
+++ b/src/main/java/jade/Window.java
@@ -11,8 +11,8 @@ import static org.lwjgl.opengl.GL11.*;
 import static org.lwjgl.system.MemoryUtil.NULL;
 
 public class Window {
-    private int width, height;
-    private String title;
+    private final int width, height;
+    private final String title;
     private long glfwWindow;
 
     public float r, g, b, a;


### PR DESCRIPTION
Fixed the **NullPointerException Error Warning** #1  by wrapping up the method call in **Objects.requireNonNull()** which checks that the specified object reference is not null and throws a NullPointerException explicitly.

Here is the short description of the wrapper from the IntelliJIdea IDE.

![Annotation 2021-08-24 111912](https://user-images.githubusercontent.com/76873719/130562974-ada0a52f-4820-40e1-8869-2c5f66c79054.png)